### PR TITLE
[UIFY-21] Display the lead on the slide

### DIFF
--- a/src/assets/icons/CloseIcon.tsx
+++ b/src/assets/icons/CloseIcon.tsx
@@ -1,0 +1,7 @@
+export default function CloseIcon(): React.JSX.Element {
+   return (
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="size-6">
+         <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+      </svg>
+   );
+}

--- a/src/components/display/DataView/DataView.tsx
+++ b/src/components/display/DataView/DataView.tsx
@@ -1,0 +1,10 @@
+import type { DataViewProps } from "./DataView.types";
+
+export default function DataView({ label, value = '---' }: DataViewProps): React.JSX.Element {
+   return (
+      <div className="flex gap-1 flex-col bg-primary-100 rounded-sm p-2 mb-2">
+        {label && <label className="text-xs">{label}:</label>}
+         <p>{value}</p>
+      </div>
+   );
+}

--- a/src/components/display/DataView/DataView.tsx
+++ b/src/components/display/DataView/DataView.tsx
@@ -1,10 +1,10 @@
 import type { DataViewProps } from "./DataView.types";
 
-export default function DataView({ label, value = '---' }: DataViewProps): React.JSX.Element {
+export default function DataView({ label, value }: DataViewProps): React.JSX.Element {
    return (
       <div className="flex gap-1 flex-col bg-primary-100 rounded-sm p-2 mb-2">
-        {label && <label className="text-xs">{label}:</label>}
-         <p>{value}</p>
+        {label && <span className="text-xs">{label}:</span>}
+         <p>{value ?? '---'}</p>
       </div>
    );
 }

--- a/src/components/display/DataView/DataView.types.ts
+++ b/src/components/display/DataView/DataView.types.ts
@@ -1,0 +1,4 @@
+export interface DataViewProps {
+   label: string;
+   value: string | React.ReactNode;
+}

--- a/src/components/display/SlideOver/SlideOver.module.css
+++ b/src/components/display/SlideOver/SlideOver.module.css
@@ -1,0 +1,18 @@
+.SlideOverBackdrop {
+   position: fixed;
+   top: 0;
+   left: 0;
+   right: 0;
+   bottom: 0;
+   transition: all 200ms;
+}
+
+.SlideOverContent {
+   position: absolute;
+   top: 0;
+   right: 0;
+   bottom: 0;
+   width: 100%;
+   max-width: var(--breakpoint-sm);
+   transition: all 200ms;
+}

--- a/src/components/display/SlideOver/SlideOver.tsx
+++ b/src/components/display/SlideOver/SlideOver.tsx
@@ -1,0 +1,43 @@
+import { parseCSS } from '@/helpers/parse';
+import styles from './SlideOver.module.css';
+import CloseIcon from '@/assets/icons/CloseIcon';
+
+// types
+import type { SlideOverProps } from './SlideOver.types';
+
+export default function SlideOver({
+   isOpen,
+   onClose,
+   children
+}: SlideOverProps): React.JSX.Element {
+   if (!isOpen) return <></>;
+
+   const handleClose = (ev: React.MouseEvent<HTMLDivElement>) => {
+      if (ev.target === ev.currentTarget) {
+         onClose();
+      }
+   };
+
+   return (
+      <div
+         className={parseCSS(styles.SlideOverBackdrop, 'bg-primary-900/30')}
+         onClick={handleClose}
+      >
+         <div className={parseCSS(styles.SlideOverContent, 'bg-primary-50 shadow-2xl')}>
+            <div className="flex items-center justify-end">
+               <button
+                  className={parseCSS(styles.SlideOverCloseButton, 'text-primary-900 hover:text-primary-700 hover:bg-primary-100 p-2 cursor-pointer')}
+                  onClick={onClose}
+                  aria-label="Close Slide Over"
+               >
+                  <CloseIcon />
+               </button>
+            </div>
+
+            <div className="px-5">
+               {children}
+            </div>
+         </div>
+      </div>
+   );
+}

--- a/src/components/display/SlideOver/SlideOver.types.ts
+++ b/src/components/display/SlideOver/SlideOver.types.ts
@@ -1,0 +1,6 @@
+import type { ComponentBaseProps } from '@/types/base.types';
+
+export interface SlideOverProps extends ComponentBaseProps {
+   isOpen: boolean;
+   onClose: () => void;
+}

--- a/src/components/display/index.tsx
+++ b/src/components/display/index.tsx
@@ -1,1 +1,2 @@
 export { default as Table } from './Table/Table';
+export { default as SlideOver } from './SlideOver/SlideOver';

--- a/src/components/tables/LeadsTable/LeadsTable.tsx
+++ b/src/components/tables/LeadsTable/LeadsTable.tsx
@@ -1,10 +1,12 @@
-import { Table } from '@/components/display';
+import { SlideOver, Table } from '@/components/display';
+import DataView from '@/components/display/DataView/DataView';
 import { LeadsFilter } from '@/components/filters';
 import { useFetch } from '@/hooks';
 
 // types
 import type { LeadData } from '@/types/data.types';
 import { useState } from 'react';
+import { createPortal } from 'react-dom';
 
 export default function LeadsTable(): React.JSX.Element {
    const {
@@ -14,13 +16,12 @@ export default function LeadsTable(): React.JSX.Element {
       error,
       loading
    } = useFetch<LeadData[]>('../../assets/data/leads.json', 'score', 'desc');
-   const [selectedLead, setSelectedLead] = useState<LeadData | null>(null);
+   const [ selectedLead, setSelectedLead ] = useState<LeadData | null>(null);
 
    const handleRowClick = (item: LeadData) => {
       setSelectedLead(item);
    };
 
-   console.log(selectedLead);
    return (
       <div>
          <LeadsFilter defaultData={defaultData} setData={setData} />
@@ -40,6 +41,28 @@ export default function LeadsTable(): React.JSX.Element {
                { key: 'score', label: 'Score' },
             ]}
          />
+
+         {createPortal((
+            <SlideOver
+               isOpen={Boolean(selectedLead)}
+               onClose={() => setSelectedLead(null)}
+            >
+               <div className="slide-header mb-2">
+                  <h2 className="text-lg">Lead Details</h2>
+                  <p className="text-sm">Here you can view and edit lead information.</p>
+               </div>
+
+               <div className="slideBody">
+                  <DataView label="ID" value={selectedLead?.id} />
+                  <DataView label="Name" value={selectedLead?.name} />
+                  <DataView label="Company" value={selectedLead?.company} />
+                  <DataView label="Email" value={selectedLead?.email} />
+                  <DataView label="Status" value={selectedLead?.status} />
+                  <DataView label="Source" value={selectedLead?.source} />
+                  <DataView label="Score" value={selectedLead?.score} />
+               </div>
+            </SlideOver>
+         ), document.querySelector('main#root') as HTMLElement)}
       </div>
    );
 }


### PR DESCRIPTION
## [UIFY-21] Description
This pull request introduces a new `SlideOver` component for displaying detailed lead information in a side panel, and a reusable `DataView` component for presenting labeled data. These additions enhance the user interface for viewing lead details in the `LeadsTable` by providing a modern, interactive slide-over panel. The changes also include new supporting types and icon components.

**New SlideOver feature and integration:**

- Added a new `SlideOver` component (`SlideOver.tsx`, `SlideOver.types.ts`, `SlideOver.module.css`) with backdrop, close button (using the new `CloseIcon`), and transition styles for displaying content in a side panel. This component is now exported from the display components index. [[1]](diffhunk://#diff-848f0e07cf910cd22a1678e9639840bc417fa338c735e77a52c4a01ba969f53fR1-R43) [[2]](diffhunk://#diff-bee0d3897335d417efde96c58ecb4210af5ad6003d62f6bb9094ccd8f63dc015R1-R18) [[3]](diffhunk://#diff-e17a8b54d0129a9a119d47af779c8602518cd652f8e59fab08d4a3e7a88e1776R1-R7) [[4]](diffhunk://#diff-d5bcf098a4502247d8137fc78b59ad56173048f2e3ad38008be5a37f2bf12e10R2) [[5]](diffhunk://#diff-788ff70760965e2f14288982b26c29eab18069dca7f002862ccddf65e96238cdR1-R6)
- Integrated the `SlideOver` into `LeadsTable` to show detailed information about a selected lead using a portal to render the panel at the root level. [[1]](diffhunk://#diff-3791cf26609d0bf769a1911a9d0ad317f601f250decc8c3d70e64244c14a3f13L1-R9) [[2]](diffhunk://#diff-3791cf26609d0bf769a1911a9d0ad317f601f250decc8c3d70e64244c14a3f13R44-R65)

**Reusable DataView component:**

- Added a new `DataView` component (`DataView.tsx`, `DataView.types.ts`) for displaying a label-value pair, used within the `SlideOver` to present lead details. [[1]](diffhunk://#diff-3459254f09a4d7273eb9ec765c5d793bfb167443120951100c1567062748f52fR1-R10) [[2]](diffhunk://#diff-17bdf0a033dd83bffdd1c121c3463100461d4398476e70b2b6ba5928e94ca45dR1-R4) [[3]](diffhunk://#diff-3791cf26609d0bf769a1911a9d0ad317f601f250decc8c3d70e64244c14a3f13L1-R9) [[4]](diffhunk://#diff-3791cf26609d0bf769a1911a9d0ad317f601f250decc8c3d70e64244c14a3f13R44-R65)

**Minor improvements:**

- Removed an unnecessary `console.log` statement from `LeadsTable` for cleaner code.

[UIFY-21]: https://feliperamosdev.atlassian.net/browse/UIFY-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ